### PR TITLE
Fix render warning

### DIFF
--- a/src/Components/EpisodeDisplay/EpisodeDisplay.js
+++ b/src/Components/EpisodeDisplay/EpisodeDisplay.js
@@ -45,7 +45,7 @@ const EpisodeDisplay = (props) => {
     if (season !== "favorites") {
       getSeasons();
     }
-  }, [getSeasons]);
+  }, [getSeasons, season]);
 
   const generateEpisodeThumbs = () => {
     return episodes.map((episode, index) => {


### PR DESCRIPTION
## Is this a fix or a feature?
This is a fix

## What is the change?
Corrects a bug

## What does it fix?
Adds second param in useEffect to clear warning

## Where should the reviewer start?
Line 48 in EpisodeDisplay

## How should this be tested?
Run`npm start` in your terminal and navigate to localhost:3000 to see current site functionality
## Relevant Issues
